### PR TITLE
Feature: Data import (from PROMPT) via API service

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -28,6 +28,7 @@ import { HighlightingToolbarComponent } from './highlighting-toolbar/highlightin
 import { Location, LocationStrategy, PathLocationStrategy } from '@angular/common';
 import { ExportOverlayComponent } from './dashboard/export-overlay/export-overlay.component';
 import { ReactiveFormsModule } from '@angular/forms';
+import { APIDataAccessService } from './shared/layers/data-access-layer/api-data-access.service';
 
 @NgModule({
   declarations: [AppComponent, OverlayHostDirective, HighlightingToolbarComponent],
@@ -50,6 +51,7 @@ import { ReactiveFormsModule } from '@angular/forms';
     DashboardModule,
   ],
   providers: [
+    APIDataAccessService,
     TeamService,
     ConstraintService,
     OverlayService,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule, HammerModule } from '@angular/platform-browser';
+import { HttpClientModule } from '@angular/common/http';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -33,6 +34,8 @@ import { ReactiveFormsModule } from '@angular/forms';
   imports: [
     /* external modules */
     BrowserModule,
+    // remember to import the HttpClientModule after the BrowserModule
+    HttpClientModule,
     BrowserAnimationsModule,
     MatButtonModule,
     MatIconModule,

--- a/src/app/dashboard/import-overlay/import-overlay.component.html
+++ b/src/app/dashboard/import-overlay/import-overlay.component.html
@@ -20,16 +20,24 @@
       <div class="flex-grow flex-column flex-basis-zero alternative-box flex-spacing-10">
         <div class="align-self-center alternative-heading">Example Data</div>
         <div>You can use example data to explore and test the app.</div>
-        <button mat-raised-button color="primary" (click)="loadExampleData()">
+        <button style="font-size: smaller;" mat-raised-button color="primary" (click)="loadExampleData()">
           <mat-icon>cloud_download</mat-icon>Load Example Data
         </button>
       </div>
-      <div class="seperator"></div>
+      <div class="separator"></div>
       <div class="flex-grow flex-column flex-basis-zero alternative-box flex-spacing-10">
         <div class="align-self-center alternative-heading">CSV File</div>
         <div>Data can be loaded from a file in the CSV format.</div>
         <button mat-raised-button color="primary" (click)="openFileInput()">
           <mat-icon>insert_drive_file</mat-icon>Choose File
+        </button>
+      </div>
+      <div class="separator"></div>
+      <div class="flex-grow flex-column flex-basis-zero alternative-box flex-spacing-10">
+        <div class="align-self-center alternative-heading">PROMPT</div>
+        <div>Data can also be retrieved from PROMPT using its API.</div>
+        <button mat-raised-button color="primary" (click)="loadFromPROMPT()">
+          <mat-icon>cloud_download</mat-icon>Download
         </button>
       </div>
     </div>

--- a/src/app/dashboard/import-overlay/import-overlay.component.scss
+++ b/src/app/dashboard/import-overlay/import-overlay.component.scss
@@ -7,7 +7,7 @@
   display: none;
 }
 
-.seperator {
+.separator {
   background-color: #AAA;
   width: 1px;
   margin: 20px 0;

--- a/src/app/dashboard/import-overlay/import-overlay.component.ts
+++ b/src/app/dashboard/import-overlay/import-overlay.component.ts
@@ -36,4 +36,8 @@ export class ImportOverlayComponent implements OnInit, OverlayComponent {
       ConstraintLoggingService.reset();
     });
   }
+
+  public loadFromPROMPT() {
+    // TODO: use team service to load data from PROMPT using the API
+  }
 }

--- a/src/app/dashboard/import-overlay/import-overlay.component.ts
+++ b/src/app/dashboard/import-overlay/import-overlay.component.ts
@@ -30,14 +30,20 @@ export class ImportOverlayComponent implements OnInit, OverlayComponent {
     });
   }
 
+  private onImported() {
+    this.data.onTeamsImported();
+    ConstraintLoggingService.reset();
+  }
+
   public loadExampleData() {
     this.teamService.readRemoteData(ExamplePersonPropertyCsvRemotePath).then(success => {
-      this.data.onTeamsImported();
-      ConstraintLoggingService.reset();
+      this.onImported();
     });
   }
 
   public loadFromPROMPT() {
-    // TODO: use team service to load data from PROMPT using the API
+    this.teamService.readFromAPI().then(success => {
+      this.onImported();
+    });
   }
 }

--- a/src/app/shared/layers/business-logic-layer/team.service.ts
+++ b/src/app/shared/layers/business-logic-layer/team.service.ts
@@ -7,6 +7,11 @@ import { CSVPersonDataAccessService } from '../data-access-layer/csv-person-data
 import { ConstraintLoggingService } from './constraint-logging.service';
 import { APIDataAccessService } from '../data-access-layer/api-data-access.service';
 
+export interface JSONBlobResponse {
+  students: any,
+  teams: any
+}
+
 @Injectable()
 export class TeamService {
   private readonly EXPORT_DATA_TYPE = 'text/csv;charset=utf-8';
@@ -104,8 +109,26 @@ export class TeamService {
     });
   }
 
-  private loadJSON(data: any) {
-    // TODO: unpack students and teams from the JSON blob
+  private loadJSON(blob: JSONBlobResponse) {
+    this.persons = this.getStudents(blob);
+    this.teams = this.getTeams(blob);
+    this.updateDerivedProperties();
+  }
+
+  private getStudents(blob: JSONBlobResponse) {
+    let students: Person[];
+    blob.students.forEach(object => {
+      students.push(object as Person);
+    })
+    return students;
+  }
+
+  private getTeams(blob: JSONBlobResponse) {
+    let teams: Team[];
+    blob.teams.forEach(object => {
+      teams.push(object as Team);
+    })
+    return teams;
   }
 
   public readFromAPI(): Promise<boolean> {

--- a/src/app/shared/layers/business-logic-layer/team.service.ts
+++ b/src/app/shared/layers/business-logic-layer/team.service.ts
@@ -5,6 +5,7 @@ import * as FileSaver from 'file-saver';
 import * as JSZip from 'jszip';
 import { CSVPersonDataAccessService } from '../data-access-layer/csv-person-data-access.service';
 import { ConstraintLoggingService } from './constraint-logging.service';
+import { APIDataAccessService } from '../data-access-layer/api-data-access.service';
 
 @Injectable()
 export class TeamService {
@@ -12,6 +13,10 @@ export class TeamService {
   private readonly EXPORT_FILE_NAME = 'TEASE-export.zip';
   private readonly LOG_EXPORT_FILE_NAME = 'constraint-distribution-log.txt';
   private readonly CSV_EXPORT_FILE_NAME = 'TEASE-project.csv';
+
+  constructor(private apiDataAccessService: APIDataAccessService) {
+
+  }
 
   teams: Team[];
   persons: Person[];
@@ -50,6 +55,14 @@ export class TeamService {
     this.updateDerivedProperties();
   }
 
+  private sortTeams() {
+    this.teams.sort((teamA, teamB) => {
+      if (teamA.name.toLowerCase() < teamB.name.toLowerCase()) return -1;
+      if (teamA.name.toLowerCase() > teamB.name.toLowerCase()) return 1;
+      return 0;
+    });
+  }
+
   // removes all persons from their team
   public resetTeamAllocation() {
     this.teams.forEach(team => team.clear());
@@ -85,6 +98,19 @@ export class TeamService {
   public readRemoteData(remoteFilePath: string): Promise<boolean> {
     return new Promise((resolve, reject) => {
       CSVPersonDataAccessService.readFromRemote(remoteFilePath).then(data => {
+        this.loadJSON(data);
+        resolve(true);
+      });
+    });
+  }
+
+  private loadJSON(data: any) {
+    // TODO: unpack students and teams from the JSON blob
+  }
+
+  public readFromAPI(): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      this.apiDataAccessService.readFromAPI().then(data => {
         this.load(data);
         resolve(true);
       });

--- a/src/app/shared/layers/business-logic-layer/team.service.ts
+++ b/src/app/shared/layers/business-logic-layer/team.service.ts
@@ -98,7 +98,7 @@ export class TeamService {
   public readRemoteData(remoteFilePath: string): Promise<boolean> {
     return new Promise((resolve, reject) => {
       CSVPersonDataAccessService.readFromRemote(remoteFilePath).then(data => {
-        this.loadJSON(data);
+        this.load(data);
         resolve(true);
       });
     });
@@ -111,7 +111,7 @@ export class TeamService {
   public readFromAPI(): Promise<boolean> {
     return new Promise((resolve, reject) => {
       this.apiDataAccessService.readFromAPI().then(data => {
-        this.load(data);
+        this.loadJSON(data);
         resolve(true);
       });
     });

--- a/src/app/shared/layers/data-access-layer/api-data-access.service.ts
+++ b/src/app/shared/layers/data-access-layer/api-data-access.service.ts
@@ -8,7 +8,7 @@ import { catchError, retry } from 'rxjs/operators';
 import { Person } from '../../models/person';
 import { Team } from '../../models/team';
 
-import { JSONBlobResponse } from '../business-logic-layer/team.service'
+import { JSONBlobResponse } from '../business-logic-layer/team.service';
 
 @Injectable()
 export class APIDataAccessService {
@@ -20,12 +20,17 @@ export class APIDataAccessService {
 
   private static readonly BROWSER_STORAGE_KEY = 'TEASE-LOCAL-JSON-BLOB';
 
+  private static STUDENT_EXAMPLE_API_RESPONSE_PATH = 'assets/students_example_api_response.json';
+  private static SKILLS_EXAMPLE_API_RESPONSE_PATH = 'assets/skills_example_api_response.json';
+
   constructor(private http: HttpClient) { }
 
-  public readFromAPI(): Promise<JSONBlobResponse> {
+  public readFromAPI(): Promise<Object> {
     return forkJoin({
-      students: ajax.getJSON(APIDataAccessService.PROMPT_API_BASE_URL + APIDataAccessService.STUDENTS_ROUTE),
-      teams: ajax.getJSON(APIDataAccessService.PROMPT_API_BASE_URL + APIDataAccessService.TEAMS_ROUTE)
+      // students: ajax.getJSON(APIDataAccessService.PROMPT_API_BASE_URL + APIDataAccessService.STUDENTS_ROUTE),
+      // teams: ajax.getJSON(APIDataAccessService.PROMPT_API_BASE_URL + APIDataAccessService.TEAMS_ROUTE)
+      students: ajax.getJSON(APIDataAccessService.STUDENT_EXAMPLE_API_RESPONSE_PATH),
+      skills: ajax.getJSON(APIDataAccessService.SKILLS_EXAMPLE_API_RESPONSE_PATH)
     }).toPromise();
   }
 

--- a/src/app/shared/layers/data-access-layer/api-data-access.service.ts
+++ b/src/app/shared/layers/data-access-layer/api-data-access.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+import { Observable, throwError } from 'rxjs';
+import { catchError, retry } from 'rxjs/operators';
+
+import { Person } from '../../models/person';
+import { Team } from '../../models/team';
+
+@Injectable()
+export class APIDataAccessService {
+  private static readonly PROMPT_API_BASE_URL = 'http://localhost:3000';
+
+  private static readonly STUDENTS_ROUTE = "students";
+  private static readonly TEAMS_ROUTE = "teams";
+
+  private static readonly BROWSER_STORAGE_KEY = 'TEASE-LOCAL-JSON-BLOB';
+
+  constructor(private http: HttpClient) { }
+
+  public readFromAPI(): Promise<any> {
+    return new Promise((resolve, reject) => {
+      // TODO: make http get requests to the API and turn them into a JSON blob
+    });
+  }
+
+  public parseBrowserStorageData(): Promise<any> {
+    return new Promise((resolve, reject) => {
+      // TOOD: parse the locally stored blob (string)
+    });
+  }
+
+  public saveToBrowserStorage(blob: any): Promise<boolean> {
+    const result = JSON.stringify(blob);
+    localStorage.setItem(APIDataAccessService.BROWSER_STORAGE_KEY, result);
+    return Promise.resolve(true);
+  }
+
+  public getStoredDataFromBrowserStorage(): string {
+    return localStorage.getItem(APIDataAccessService.BROWSER_STORAGE_KEY);
+  }
+
+  public clearStoredData() {
+    localStorage.removeItem(APIDataAccessService.BROWSER_STORAGE_KEY);
+  }
+}

--- a/src/app/shared/layers/data-access-layer/api-data-access.service.ts
+++ b/src/app/shared/layers/data-access-layer/api-data-access.service.ts
@@ -1,15 +1,19 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 
-import { Observable, throwError } from 'rxjs';
+import { Observable, throwError, forkJoin } from 'rxjs';
+import { ajax } from 'rxjs/ajax'
 import { catchError, retry } from 'rxjs/operators';
 
 import { Person } from '../../models/person';
 import { Team } from '../../models/team';
 
+import { JSONBlobResponse } from '../business-logic-layer/team.service'
+
 @Injectable()
 export class APIDataAccessService {
-  private static readonly PROMPT_API_BASE_URL = 'http://localhost:3000';
+  // TODO: set to actual URL from which PROMPT makes its endpoints available
+  private static readonly PROMPT_API_BASE_URL = 'http://localhost:3000/v1';
 
   private static readonly STUDENTS_ROUTE = "students";
   private static readonly TEAMS_ROUTE = "teams";
@@ -18,15 +22,16 @@ export class APIDataAccessService {
 
   constructor(private http: HttpClient) { }
 
-  public readFromAPI(): Promise<any> {
-    return new Promise((resolve, reject) => {
-      // TODO: make http get requests to the API and turn them into a JSON blob
-    });
+  public readFromAPI(): Promise<JSONBlobResponse> {
+    return forkJoin({
+      students: ajax.getJSON(APIDataAccessService.PROMPT_API_BASE_URL + APIDataAccessService.STUDENTS_ROUTE),
+      teams: ajax.getJSON(APIDataAccessService.PROMPT_API_BASE_URL + APIDataAccessService.TEAMS_ROUTE)
+    }).toPromise();
   }
 
-  public parseBrowserStorageData(): Promise<any> {
+  public parseBrowserStorageData(): Promise<JSONBlobResponse> {
     return new Promise((resolve, reject) => {
-      // TOOD: parse the locally stored blob (string)
+      // TODO: parse the locally stored blob (string)
     });
   }
 

--- a/src/assets/skills_example_api_response copy.json
+++ b/src/assets/skills_example_api_response copy.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    "title": "iOS Development",
+    "description": "Development of applications for the iOS mobile operating system"
+  },
+  {
+    "id": "3fa86f64-5717-4562-b3fc-2c163f66afa6",
+    "title": "Machine Learning",
+    "description": "Machine learning experience in frameworks such as Tensorflow to train on various data sets"
+  },
+  {
+    "id": "3fa35f54-5717-4562-b3fc-2c963f66afa6",
+    "title": "VR Development",
+    "description": "Development of virtual reality systems"
+  }
+]

--- a/src/assets/students_example_api_response.json
+++ b/src/assets/students_example_api_response.json
@@ -1,0 +1,137 @@
+[
+  {
+    "firstName": "Aerandir",
+    "lastName": "Brandybuck",
+    "image": "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAABhWlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw0AcxV9Ta4tUHOyg4pChOlmQKuKoVShChVArtOpgcumH0KQhSXFxFFwLDn4sVh1cnHV1cBUEwQ8QVxcnRRcp8X9JoUWsB8f9eHfvcfcOEOplplld44Cm22Y6mRCzuRUx+IoABhFCHN0ys4xZSUqh4/i6h4+vdzGe1fncn6NXzVsM8InEM8wwbeJ14qlN2+C8TxxhJVklPiceM+mCxI9cVzx+41x0WeCZETOTniOOEIvFNlbamJVMjXiSOKpqOuULWY9VzluctXKVNe/JXxjO68tLXKc5jCQWsAgJIhRUsYEybMRo1UmxkKb9RAf/kOuXyKWQawOMHPOoQIPs+sH/4He3VmEi7iWFE0DgxXE+RoDgLtCoOc73seM0TgD/M3Clt/yVOjD9SXqtpUWPgL5t4OK6pSl7wOUOMPBkyKbsSn6aQqEAvJ/RN+WA/lugZ9XrrbmP0wcgQ12lboCDQ2C0SNlrHd4dau/t3zPN/n4AXNxynqXamwQAAAAGYktHRAD/AP8A/6C9p5MAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAisSURBVFjDRZfLkiRJUkWPqpk/IyIzMuvR1dUMw/DY9ICw4hv4P/6CFX/AgsWIIMIWAWSQbmGqurvemRmZEeHuZqrKwqNmXMQXvnFVM9N77jX553/6l8AMECICJJAoJISGhc5PDE9vOL3/T978+L+8f3zkUI2n2fGmJbTFSiGksN3tGfpn+LygVLq2QdNAHp7z/T/8I7J/DqLIpZaIkAkQEQBEQRAI6OLIsHyhl5np7gNPH98zz48sy8TDdOasPRotTeqQNGA2s9SWNDvzdKb4kTG2tE1myGceP/zIi82I9VsCJQABcogQAiKg4uBBtjPD8hPy5X+oZeL0+TOlPlGsEDlBN1BJRBjEQi0LRJBIZFVmZhY3/DTRNQ0pTfz+v/6DZuzY/+q3mAqgAOSqzrp8R11QOzP98t9c9XdMp4+U44nz9ETqG7TpmKdKjUTTtlg4xSaWeUJTImUBdwxbV5QCD8PF0FYpdkajUkxBMxGgSPD1ERHK+Z5eHzge/g/ECM2UUO6PxrEkam6QtifRkqxBitAmITcGGGWaUM9shh1tM9K1HW4GBG/f/sD5fI8kQSShquSEEgEQZK20zZlnt0pXXzIfzwQT890Jl4H+ds8Nzk4GhJ5aKvNyxnwmkgKCWSWqUWtBk4LCvEzkLDAfWeyJbfqWiLQOoYYSBIQipozthn7ZcPf2R7zOLNLiOqD9ll4HGhIpjfTjHk+OR2VaZkQahmEEBffCND1yPD5yd/+ZaTqzlIJY4XQ6sLl11lULGQkIkIjLVCpRKp/e/cRPnw/45huub56TdIPPGTWh6RIZQXREc2YzGJoSWbe4CSk5PizY1cK2f8fbn35gjoV5mSg2Y1QkKkomx1odJRAqKSrZlaDlFBua/haTHZSMm6MeaAReK6oZBMQV8USIoZ7AEk3aIl64HeGu/cT59AFF6dsRglWEEmgK0AAhkDAylc8fPvLmD+/wtkXbFqLBEUIcy8EilVInzBbcHHfHTXFTIgRCCFeUhiw9+6vnJG3JbUM37nC7zFzO5JQSZnbpKtBYmKcjuhlgaMmSsRAijJBAVJnDcQkSgkoip45qQeCEKCIKBMQqcdWGTb8luo6mGy+nHrg7OWT9QILwwrwcuTvc4W1Danpy0xHVWMqM24LmFtEgNNE1gQOEEnFei6cMChEOEqAr5VQzHgqSVggJRATZLkyMWDH8dDrQbBr8vmPsrsgotRp1mql1xiiUpSKhTJtH9je37K72lFJJyWlzg7D+fCWlgzsRTt93F88RvDpEJSuJCEdDaELpuo4ngt3VDnJLVCOjjP1IsYS2LSm1LMeZcj5zuPvI2Lcs88zp6SN3+TOb8ZbNZkdqgsAwLwRB7jogr96HEyFk47JVYXjA4i0PUzCMPaYNZVbMg+M8M81nyunM1W5PWSpNagkLVJShHzjc3VMf71nqgeO8Zxh6urblXCZMjZtvXiPagq875G5kkcBYGSDzjD0uvH75Z1y9HBC95v3PD3x4d2B3vWffPkObFiXz4A/4PNH0K8iG4YrNtvLu+IY8L2yuMjlllloInN3LFzx//Ss88uV4VgfOEeu0NvdH7Hf/Tns+IH/Ts//NnnkRxhykZKg0tNoByjJPRJ3R7OS8IlVI7G9e0ww3AJRlgdzQdYlmeOQv//bvEbnBLP3RdyKCLBGkCNrDxPih0Fpwd3emnIPjwxOPHx+gGFVmcEVCWOYzIhVNoJqR1GGqNH1mm7aoNGhapVt8Yrze02+esViHhBDYGn6ArBEo0Iwj0Q1sfr9gW5i+LByWhclkPaBaqeXEOthBK4mIQEPRUJKvCJaUEM2sVHFEhLEZaaIjUiLcsACRrw1ooCJw1VP//JrHTw+cgOPdGetbqiiBIoD5pfPiLHOhWqW2BT8b3faK3f4FXXtNSi21nnE38Mr54wP+7Yl8M2ApE1TcV0jllDIiQXWw37ziUzkwLwfK4ZHWR0QyKSnEWtxxPAlN37Ht9ozjlm4YCOnwEOZlJnvFo2AsqAXXMtKaMLtDasi5xZaCmZFzzrhXSgb97hXN8YH4w5kShVoXnBXBaIDHCrY2kbThev+Mthloug7JmblUapkxApdYt3t2djc3yHbERFGCnBqsFWqt5LZtMReKwND3jN//Hem71xzvfuaXX97iHsAltnnAYjiw2IxXZxh3bHc7unFcDS59FXVAEqRt2X73LXXoyTljFwa0baZtMznUVzarsgQ03UhsAj8/UAPcL+gkqASHwwP3nz4TXeLq2Z5meiDeGS9evOT65TeQGy7uQtKW4foZfr3Dmwa9SM/c/8SBLInVI1ZeiydS15OS0uUEiwGKqUJO3Nzect1f0242xFXH/f0XTo8HpvPCZlpot2sDnoQ87ti8fEUlofGnGACOmawkTLqSyUUJCVJSFPBa2Qwt03n6yklEFcmQG6GrQn9qedb9Gv2rjnSdKfh6WipcffOM3cu/IGJL8Vhpf7l3iAgi0ORMnm3B3TFfwSIRLOeJU6nM4liXKGaXHB+IQ6gxnZ+I2djubkntFk9gBMkVTR3j7hVGvyZfWSXssjJFZF2MCuRqhpkTYUhqsHDMAzDOxyekClRDvs5VVvJ1y/Bsi9Ki3Yh1iSqORyAI7WYHOmBFiFRRyQiZuhTQQFUhAgvIIYEkCFdKLSSHduiYPOFFiVKQNUNdrk8KKmiTyc2I5g2uEFFwU5CMaIdoi6QEOKVWAiVrxi8ENLM1ltepEOGrQ7ldEjKI5IttXgpHEO6UatRlQS3R9aASEJkaDi4kTZSnI9iaASyCiIR9vREKxEUNKSl5mea1AKy087URCUXM1oFcd/+PHu61cCifaMtELjPSdHTNSJ86NIIv7z/w89MX/vq336PtgPuK8+p6mSUhcEpZ0DXVra/IepNJuqBS17RsFw2IrAqKWFUhawIWlC41DHmg8Yyi3Lx6xQ8/vuHffvevPBx/QXMhqdOIkwUER2Kl6v8DhzhPSk7slXkAAAAASUVORK5CYII=",
+    "email": "aerandir.brandybuck@tum.de",
+    "tumId": 46035297,
+    "gender": "Prefer not to say",
+    "nationality": "DE",
+    "studyProgram": "IN-B",
+    "semester": 6,
+    "germanLanguageLevel": "Native",
+    "englishLanguageLevel": "B1/B2",
+    "introSelfAssessment": "Intermediate",
+    "devices": [
+      "IPhone",
+      "Mac"
+    ],
+    "skills": [
+      {
+        "skillId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        "skillLevel": "Novice",
+        "skillLevelRationale": "Only dabbled a tiny bit with Swift"
+      },
+      {
+        "skillId": "3fa85f64-6717-5562-c3fc-2c963f66afa6",
+        "skillLevel": "Intermediate",
+        "skillLevelRationale": "Wrote a project for a seminar that used this skill"
+      }
+    ],
+    "projectPriorities": [
+      {
+        "name": "Quartett",
+        "id": "ios2223quartett"
+      },
+      {
+        "name": "BSH",
+        "id": "ios2223bsh"
+      }
+    ],
+    "studentComments": "I would prefer to work in an international team (diverse nationalities), thanks!",
+    "supervisorAssessment": "Novice",
+    "tutorComments": "Motivated, good at accepting constructive criticism",
+    "isPinned": false,
+    "project": null
+  },
+  {
+    "firstName": "Lobelia",
+    "lastName": "Hildeson",
+    "image": "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAABhWlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw0AcxV9Ta4tUHOyg4pChOlmQKuKoVShChVArtOpgcumH0KQhSXFxFFwLDn4sVh1cnHV1cBUEwQ8QVxcnRRcp8X9JoUWsB8f9eHfvcfcOEOplplld44Cm22Y6mRCzuRUx+IoABhFCHN0ys4xZSUqh4/i6h4+vdzGe1fncn6NXzVsM8InEM8wwbeJ14qlN2+C8TxxhJVklPiceM+mCxI9cVzx+41x0WeCZETOTniOOEIvFNlbamJVMjXiSOKpqOuULWY9VzluctXKVNe/JXxjO68tLXKc5jCQWsAgJIhRUsYEybMRo1UmxkKb9RAf/kOuXyKWQawOMHPOoQIPs+sH/4He3VmEi7iWFE0DgxXE+RoDgLtCoOc73seM0TgD/M3Clt/yVOjD9SXqtpUWPgL5t4OK6pSl7wOUOMPBkyKbsSn6aQqEAvJ/RN+WA/lugZ9XrrbmP0wcgQ12lboCDQ2C0SNlrHd4dau/t3zPN/n4AXNxynqXamwQAAAAGYktHRAD/AP8A/6C9p5MAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAisSURBVFjDRZfLkiRJUkWPqpk/IyIzMuvR1dUMw/DY9ICw4hv4P/6CFX/AgsWIIMIWAWSQbmGqurvemRmZEeHuZqrKwqNmXMQXvnFVM9N77jX553/6l8AMECICJJAoJISGhc5PDE9vOL3/T978+L+8f3zkUI2n2fGmJbTFSiGksN3tGfpn+LygVLq2QdNAHp7z/T/8I7J/DqLIpZaIkAkQEQBEQRAI6OLIsHyhl5np7gNPH98zz48sy8TDdOasPRotTeqQNGA2s9SWNDvzdKb4kTG2tE1myGceP/zIi82I9VsCJQABcogQAiKg4uBBtjPD8hPy5X+oZeL0+TOlPlGsEDlBN1BJRBjEQi0LRJBIZFVmZhY3/DTRNQ0pTfz+v/6DZuzY/+q3mAqgAOSqzrp8R11QOzP98t9c9XdMp4+U44nz9ETqG7TpmKdKjUTTtlg4xSaWeUJTImUBdwxbV5QCD8PF0FYpdkajUkxBMxGgSPD1ERHK+Z5eHzge/g/ECM2UUO6PxrEkam6QtifRkqxBitAmITcGGGWaUM9shh1tM9K1HW4GBG/f/sD5fI8kQSShquSEEgEQZK20zZlnt0pXXzIfzwQT890Jl4H+ds8Nzk4GhJ5aKvNyxnwmkgKCWSWqUWtBk4LCvEzkLDAfWeyJbfqWiLQOoYYSBIQipozthn7ZcPf2R7zOLNLiOqD9ll4HGhIpjfTjHk+OR2VaZkQahmEEBffCND1yPD5yd/+ZaTqzlIJY4XQ6sLl11lULGQkIkIjLVCpRKp/e/cRPnw/45huub56TdIPPGTWh6RIZQXREc2YzGJoSWbe4CSk5PizY1cK2f8fbn35gjoV5mSg2Y1QkKkomx1odJRAqKSrZlaDlFBua/haTHZSMm6MeaAReK6oZBMQV8USIoZ7AEk3aIl64HeGu/cT59AFF6dsRglWEEmgK0AAhkDAylc8fPvLmD+/wtkXbFqLBEUIcy8EilVInzBbcHHfHTXFTIgRCCFeUhiw9+6vnJG3JbUM37nC7zFzO5JQSZnbpKtBYmKcjuhlgaMmSsRAijJBAVJnDcQkSgkoip45qQeCEKCIKBMQqcdWGTb8luo6mGy+nHrg7OWT9QILwwrwcuTvc4W1Danpy0xHVWMqM24LmFtEgNNE1gQOEEnFei6cMChEOEqAr5VQzHgqSVggJRATZLkyMWDH8dDrQbBr8vmPsrsgotRp1mql1xiiUpSKhTJtH9je37K72lFJJyWlzg7D+fCWlgzsRTt93F88RvDpEJSuJCEdDaELpuo4ngt3VDnJLVCOjjP1IsYS2LSm1LMeZcj5zuPvI2Lcs88zp6SN3+TOb8ZbNZkdqgsAwLwRB7jogr96HEyFk47JVYXjA4i0PUzCMPaYNZVbMg+M8M81nyunM1W5PWSpNagkLVJShHzjc3VMf71nqgeO8Zxh6urblXCZMjZtvXiPagq875G5kkcBYGSDzjD0uvH75Z1y9HBC95v3PD3x4d2B3vWffPkObFiXz4A/4PNH0K8iG4YrNtvLu+IY8L2yuMjlllloInN3LFzx//Ss88uV4VgfOEeu0NvdH7Hf/Tns+IH/Ts//NnnkRxhykZKg0tNoByjJPRJ3R7OS8IlVI7G9e0ww3AJRlgdzQdYlmeOQv//bvEbnBLP3RdyKCLBGkCNrDxPih0Fpwd3emnIPjwxOPHx+gGFVmcEVCWOYzIhVNoJqR1GGqNH1mm7aoNGhapVt8Yrze02+esViHhBDYGn6ArBEo0Iwj0Q1sfr9gW5i+LByWhclkPaBaqeXEOthBK4mIQEPRUJKvCJaUEM2sVHFEhLEZaaIjUiLcsACRrw1ooCJw1VP//JrHTw+cgOPdGetbqiiBIoD5pfPiLHOhWqW2BT8b3faK3f4FXXtNSi21nnE38Mr54wP+7Yl8M2ApE1TcV0jllDIiQXWw37ziUzkwLwfK4ZHWR0QyKSnEWtxxPAlN37Ht9ozjlm4YCOnwEOZlJnvFo2AsqAXXMtKaMLtDasi5xZaCmZFzzrhXSgb97hXN8YH4w5kShVoXnBXBaIDHCrY2kbThev+Mthloug7JmblUapkxApdYt3t2djc3yHbERFGCnBqsFWqt5LZtMReKwND3jN//Hem71xzvfuaXX97iHsAltnnAYjiw2IxXZxh3bHc7unFcDS59FXVAEqRt2X73LXXoyTljFwa0baZtMznUVzarsgQ03UhsAj8/UAPcL+gkqASHwwP3nz4TXeLq2Z5meiDeGS9evOT65TeQGy7uQtKW4foZfr3Dmwa9SM/c/8SBLInVI1ZeiydS15OS0uUEiwGKqUJO3Nzect1f0242xFXH/f0XTo8HpvPCZlpot2sDnoQ87ti8fEUlofGnGACOmawkTLqSyUUJCVJSFPBa2Qwt03n6yklEFcmQG6GrQn9qedb9Gv2rjnSdKfh6WipcffOM3cu/IGJL8Vhpf7l3iAgi0ORMnm3B3TFfwSIRLOeJU6nM4liXKGaXHB+IQ6gxnZ+I2djubkntFk9gBMkVTR3j7hVGvyZfWSXssjJFZF2MCuRqhpkTYUhqsHDMAzDOxyekClRDvs5VVvJ1y/Bsi9Ki3Yh1iSqORyAI7WYHOmBFiFRRyQiZuhTQQFUhAgvIIYEkCFdKLSSHduiYPOFFiVKQNUNdrk8KKmiTyc2I5g2uEFFwU5CMaIdoi6QEOKVWAiVrxi8ENLM1ltepEOGrQ7ldEjKI5IttXgpHEO6UatRlQS3R9aASEJkaDi4kTZSnI9iaASyCiIR9vREKxEUNKSl5mea1AKy087URCUXM1oFcd/+PHu61cCifaMtELjPSdHTNSJ86NIIv7z/w89MX/vq336PtgPuK8+p6mSUhcEpZ0DXVra/IepNJuqBS17RsFw2IrAqKWFUhawIWlC41DHmg8Yyi3Lx6xQ8/vuHffvevPBx/QXMhqdOIkwUER2Kl6v8DhzhPSk7slXkAAAAASUVORK5CYII=",
+    "email": "lobelia.hildeson@tum.de",
+    "tumId": 51033497,
+    "gender": "Female",
+    "nationality": "US",
+    "studyProgram": "IN-M",
+    "semester": 2,
+    "germanLanguageLevel": "B1/B2",
+    "englishLanguageLevel": "C1/C2",
+    "introSelfAssessment": "Advanced",
+    "devices": [
+      "IPhone",
+      "Mac",
+      "Watch"
+    ],
+    "skills": [
+      {
+        "skillId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        "skillLevel": "Intermediate",
+        "skillLevelRationale": "Wrote an iOS app for a different course"
+      },
+      {
+        "skillId": "3fa85f64-6717-5562-c3fc-2c963f66afa6",
+        "skillLevel": "Novice",
+        "skillLevelRationale": "Never had to use this in my previous work much"
+      }
+    ],
+    "projectPriorities": [
+      {
+        "name": "Quartett",
+        "id": "ios2223quartett"
+      },
+      {
+        "name": "BSH",
+        "id": "ios2223bsh"
+      }
+    ],
+    "studentComments": "I will not be in Munich for the first three weeks of the semester, I hope that's alright",
+    "supervisorAssessment": "Intermediate",
+    "tutorComments": "Has expressed that they can't work in the BSH project due to already having a contract with them",
+    "isPinned": false,
+    "project": null
+  },
+  {
+    "firstName": "Zimrahin",
+    "lastName": "Gamwich",
+    "image": "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAABhWlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw0AcxV9Ta4tUHOyg4pChOlmQKuKoVShChVArtOpgcumH0KQhSXFxFFwLDn4sVh1cnHV1cBUEwQ8QVxcnRRcp8X9JoUWsB8f9eHfvcfcOEOplplld44Cm22Y6mRCzuRUx+IoABhFCHN0ys4xZSUqh4/i6h4+vdzGe1fncn6NXzVsM8InEM8wwbeJ14qlN2+C8TxxhJVklPiceM+mCxI9cVzx+41x0WeCZETOTniOOEIvFNlbamJVMjXiSOKpqOuULWY9VzluctXKVNe/JXxjO68tLXKc5jCQWsAgJIhRUsYEybMRo1UmxkKb9RAf/kOuXyKWQawOMHPOoQIPs+sH/4He3VmEi7iWFE0DgxXE+RoDgLtCoOc73seM0TgD/M3Clt/yVOjD9SXqtpUWPgL5t4OK6pSl7wOUOMPBkyKbsSn6aQqEAvJ/RN+WA/lugZ9XrrbmP0wcgQ12lboCDQ2C0SNlrHd4dau/t3zPN/n4AXNxynqXamwQAAAAGYktHRAD/AP8A/6C9p5MAAAAJcEhZcwAAFiUAABYlAUlSJPAAAAisSURBVFjDRZfLkiRJUkWPqpk/IyIzMuvR1dUMw/DY9ICw4hv4P/6CFX/AgsWIIMIWAWSQbmGqurvemRmZEeHuZqrKwqNmXMQXvnFVM9N77jX553/6l8AMECICJJAoJISGhc5PDE9vOL3/T978+L+8f3zkUI2n2fGmJbTFSiGksN3tGfpn+LygVLq2QdNAHp7z/T/8I7J/DqLIpZaIkAkQEQBEQRAI6OLIsHyhl5np7gNPH98zz48sy8TDdOasPRotTeqQNGA2s9SWNDvzdKb4kTG2tE1myGceP/zIi82I9VsCJQABcogQAiKg4uBBtjPD8hPy5X+oZeL0+TOlPlGsEDlBN1BJRBjEQi0LRJBIZFVmZhY3/DTRNQ0pTfz+v/6DZuzY/+q3mAqgAOSqzrp8R11QOzP98t9c9XdMp4+U44nz9ETqG7TpmKdKjUTTtlg4xSaWeUJTImUBdwxbV5QCD8PF0FYpdkajUkxBMxGgSPD1ERHK+Z5eHzge/g/ECM2UUO6PxrEkam6QtifRkqxBitAmITcGGGWaUM9shh1tM9K1HW4GBG/f/sD5fI8kQSShquSEEgEQZK20zZlnt0pXXzIfzwQT890Jl4H+ds8Nzk4GhJ5aKvNyxnwmkgKCWSWqUWtBk4LCvEzkLDAfWeyJbfqWiLQOoYYSBIQipozthn7ZcPf2R7zOLNLiOqD9ll4HGhIpjfTjHk+OR2VaZkQahmEEBffCND1yPD5yd/+ZaTqzlIJY4XQ6sLl11lULGQkIkIjLVCpRKp/e/cRPnw/45huub56TdIPPGTWh6RIZQXREc2YzGJoSWbe4CSk5PizY1cK2f8fbn35gjoV5mSg2Y1QkKkomx1odJRAqKSrZlaDlFBua/haTHZSMm6MeaAReK6oZBMQV8USIoZ7AEk3aIl64HeGu/cT59AFF6dsRglWEEmgK0AAhkDAylc8fPvLmD+/wtkXbFqLBEUIcy8EilVInzBbcHHfHTXFTIgRCCFeUhiw9+6vnJG3JbUM37nC7zFzO5JQSZnbpKtBYmKcjuhlgaMmSsRAijJBAVJnDcQkSgkoip45qQeCEKCIKBMQqcdWGTb8luo6mGy+nHrg7OWT9QILwwrwcuTvc4W1Danpy0xHVWMqM24LmFtEgNNE1gQOEEnFei6cMChEOEqAr5VQzHgqSVggJRATZLkyMWDH8dDrQbBr8vmPsrsgotRp1mql1xiiUpSKhTJtH9je37K72lFJJyWlzg7D+fCWlgzsRTt93F88RvDpEJSuJCEdDaELpuo4ngt3VDnJLVCOjjP1IsYS2LSm1LMeZcj5zuPvI2Lcs88zp6SN3+TOb8ZbNZkdqgsAwLwRB7jogr96HEyFk47JVYXjA4i0PUzCMPaYNZVbMg+M8M81nyunM1W5PWSpNagkLVJShHzjc3VMf71nqgeO8Zxh6urblXCZMjZtvXiPagq875G5kkcBYGSDzjD0uvH75Z1y9HBC95v3PD3x4d2B3vWffPkObFiXz4A/4PNH0K8iG4YrNtvLu+IY8L2yuMjlllloInN3LFzx//Ss88uV4VgfOEeu0NvdH7Hf/Tns+IH/Ts//NnnkRxhykZKg0tNoByjJPRJ3R7OS8IlVI7G9e0ww3AJRlgdzQdYlmeOQv//bvEbnBLP3RdyKCLBGkCNrDxPih0Fpwd3emnIPjwxOPHx+gGFVmcEVCWOYzIhVNoJqR1GGqNH1mm7aoNGhapVt8Yrze02+esViHhBDYGn6ArBEo0Iwj0Q1sfr9gW5i+LByWhclkPaBaqeXEOthBK4mIQEPRUJKvCJaUEM2sVHFEhLEZaaIjUiLcsACRrw1ooCJw1VP//JrHTw+cgOPdGetbqiiBIoD5pfPiLHOhWqW2BT8b3faK3f4FXXtNSi21nnE38Mr54wP+7Yl8M2ApE1TcV0jllDIiQXWw37ziUzkwLwfK4ZHWR0QyKSnEWtxxPAlN37Ht9ozjlm4YCOnwEOZlJnvFo2AsqAXXMtKaMLtDasi5xZaCmZFzzrhXSgb97hXN8YH4w5kShVoXnBXBaIDHCrY2kbThev+Mthloug7JmblUapkxApdYt3t2djc3yHbERFGCnBqsFWqt5LZtMReKwND3jN//Hem71xzvfuaXX97iHsAltnnAYjiw2IxXZxh3bHc7unFcDS59FXVAEqRt2X73LXXoyTljFwa0baZtMznUVzarsgQ03UhsAj8/UAPcL+gkqASHwwP3nz4TXeLq2Z5meiDeGS9evOT65TeQGy7uQtKW4foZfr3Dmwa9SM/c/8SBLInVI1ZeiydS15OS0uUEiwGKqUJO3Nzect1f0242xFXH/f0XTo8HpvPCZlpot2sDnoQ87ti8fEUlofGnGACOmawkTLqSyUUJCVJSFPBa2Qwt03n6yklEFcmQG6GrQn9qedb9Gv2rjnSdKfh6WipcffOM3cu/IGJL8Vhpf7l3iAgi0ORMnm3B3TFfwSIRLOeJU6nM4liXKGaXHB+IQ6gxnZ+I2djubkntFk9gBMkVTR3j7hVGvyZfWSXssjJFZF2MCuRqhpkTYUhqsHDMAzDOxyekClRDvs5VVvJ1y/Bsi9Ki3Yh1iSqORyAI7WYHOmBFiFRRyQiZuhTQQFUhAgvIIYEkCFdKLSSHduiYPOFFiVKQNUNdrk8KKmiTyc2I5g2uEFFwU5CMaIdoi6QEOKVWAiVrxi8ENLM1ltepEOGrQ7ldEjKI5IttXgpHEO6UatRlQS3R9aASEJkaDi4kTZSnI9iaASyCiIR9vREKxEUNKSl5mea1AKy087URCUXM1oFcd/+PHu61cCifaMtELjPSdHTNSJ86NIIv7z/w89MX/vq336PtgPuK8+p6mSUhcEpZ0DXVra/IepNJuqBS17RsFw2IrAqKWFUhawIWlC41DHmg8Yyi3Lx6xQ8/vuHffvevPBx/QXMhqdOIkwUER2Kl6v8DhzhPSk7slXkAAAAASUVORK5CYII=",
+    "email": "zimrahin.gamwich@tum.de",
+    "tumId": 12265597,
+    "gender": "Male",
+    "nationality": "DE",
+    "studyProgram": "IN-B",
+    "semester": 5,
+    "germanLanguageLevel": "Native",
+    "englishLanguageLevel": "C1/C2",
+    "introSelfAssessment": "Expert",
+    "devices": [
+      "IPhone"
+    ],
+    "skills": [
+      {
+        "skillId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        "skillLevel": "Expert",
+        "skillLevelRationale": "Many years developing iOS apps for various companies"
+      },
+      {
+        "skillId": "3fa85f64-6717-5562-c3fc-2c963f66afa6",
+        "skillLevel": "Novice",
+        "skillLevelRationale": "Never done anything related to this"
+      }
+    ],
+    "projectPriorities": [
+      {
+        "name": "Quartett",
+        "id": "ios2223quartett"
+      },
+      {
+        "name": "BSH",
+        "id": "ios2223bsh"
+      }
+    ],
+    "studentComments": "N/A",
+    "supervisorAssessment": "Expert",
+    "tutorComments": "Demonstrated a very deep understanding of structuring the architecture of an iOS application",
+    "isPinned": false,
+    "project": null
+  }
+]


### PR DESCRIPTION
What changed: A new data access service now exists alongside the CSV data access service. This new service will retrieve data on students of the iPraktikum from PROMPT via calls to its RESTful API. A third option when opening the import overlay now explains that TEASE can download the data from PROMPT with the click of a button.

Why the changes: In addition to manually importing data from a CSV file, TEASE should be able to import the necessary data from the course management tool PROMPT.

Testing steps: To be determined as the API calls are currently incomplete (still needs to be given the correct URL etc.), to test this in the future without needing to spin up an instance of PROMPT there should be a local mocked endpoint that returns example data at a testing URL, for example `localhost:8000/example/students`.