### PR TITLE
Migrate image tags and workflow to prompt-edu org

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -21,13 +21,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - image-name: ls1intum/tease-client
+          - image-name: prompt-edu/tease-client
             docker-file: ./client/Dockerfile
             docker-context: ./client
-          - image-name: ls1intum/tease-server
+          - image-name: prompt-edu/tease-server
             docker-file: ./server/Dockerfile
             docker-context: ./server
-    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.1.1
+    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.2.0
     secrets: inherit
     with:
       image-name: ${{ matrix.image-name }}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   tease:
-    image: ghcr.io/ls1intum/tease-client:${TEASE_IMAGE_TAG:-latest}
+    image: ghcr.io/prompt-edu/tease-client:${TEASE_IMAGE_TAG:-latest}
     container_name: tease
     labels:
       - "traefik.enable=true"
@@ -15,7 +15,7 @@ services:
       - prompt-network
 
   tease-server:
-    image: ghcr.io/ls1intum/tease-server:${TEASE_IMAGE_TAG:-latest}
+    image: ghcr.io/prompt-edu/tease-server:${TEASE_IMAGE_TAG:-latest}
     container_name: tease-server
     labels:
       - "traefik.enable=true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - "80:80"
       - "8080:8080"
   tease:
-    image: ghcr.io/ls1intum/tease-client:latest
+    image: ghcr.io/prompt-edu/tease-client:latest
     container_name: tease
     labels:
       - "traefik.enable=true"
@@ -26,7 +26,7 @@ services:
     expose:
       - "80"
   tease-server:
-    image: ghcr.io/ls1intum/tease-server:latest
+    image: ghcr.io/prompt-edu/tease-server:latest
     build: ./server
     container_name: tease-server
     labels:


### PR DESCRIPTION
## Summary

- Update all Docker image references from `ghcr.io/ls1intum/tease-*` to `ghcr.io/prompt-edu/tease-*` in `docker-compose.yml` and `docker-compose.prod.yml`
- Update image names in `.github/workflows/build-and-push.yml` to use `prompt-edu/tease-client` and `prompt-edu/tease-server`
- Bump reusable workflow version from `v1.1.1` to `v1.2.0`

## Test plan
- [ ] Verify images are pushed to `ghcr.io/prompt-edu/tease-client` and `ghcr.io/prompt-edu/tease-server` after merge
- [ ] Verify deployment pulls images from the new registry paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image registry sources for both development and production deployment environments to ensure consistent and reliable image delivery across all systems
  * Updated build automation workflow configuration and version to improve overall system compatibility
  * All existing network configuration, port mappings, and service settings have been preserved

<!-- end of auto-generated comment: release notes by coderabbit.ai -->