### PR TITLE
Fix/collaboration distribute sync

### DIFF
--- a/client/src/app/components/constraint-summary-view/constraint-summary.component.ts
+++ b/client/src/app/components/constraint-summary-view/constraint-summary.component.ts
@@ -113,9 +113,18 @@ export class ConstraintSummaryComponent implements OverlayComponentData, OnInit,
     );
     const allocations = await this.matchingService.getAllocations(constraints);
     if (allocations) {
-      // PR note: the LP solver callback can complete outside Angular change detection.
-      // Re-enter the zone so the freshly computed allocations render immediately after one click.
+      // The LP solver callback can complete outside Angular change detection.
+      // Re-enter the zone so the freshly computed allocations render immediately
+      // after one click. Inside the zone we also re-broadcast the constraint +
+      // lock state used by this solve BEFORE pushing the new allocation, so
+      // peers can never see allocations without the producing inputs — cheap
+      // insurance against earlier broadcasts having dropped silently (e.g. a
+      // brief WS hiccup) and against cross-topic ordering surprises at the
+      // receiver.
       this.ngZone.run(() => {
+        this.constraintsService.setConstraints(this.constraintsService.getConstraints());
+        this.lockedStudentsService.setLocks(this.lockedStudentsService.getLocks());
+
         this.allocationsService.setAllocations(
           this.studentSortService.sortStudentsInAllocations(this.studentsService.getStudents(), allocations)
         );

--- a/client/src/app/components/navigation-bar/navigation-bar.component.html
+++ b/client/src/app/components/navigation-bar/navigation-bar.component.html
@@ -7,7 +7,7 @@
         {{ allocationData.courseIteration.semesterName }}
       </div>
 
-      @if (websocketService.connection?.connected) {
+      @if (websocketService.connected$ | async) {
         <fa-icon
           [icon]="facCheckIcon"
           class="collaboration-indicator success"

--- a/client/src/app/shared/network/websocket.service.ts
+++ b/client/src/app/shared/network/websocket.service.ts
@@ -1,14 +1,20 @@
 import { Injectable } from '@angular/core';
 import { CompatClient, Stomp, StompSubscription } from '@stomp/stompjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { Allocation } from 'src/app/api/models';
 import { ConstraintWrapper } from '../matching/constraints/constraint';
 import { GLOBALS } from '../utils/constants';
 
+/** Snapshot of a peer's collaboration state, returned via the discovery topic. */
 export interface CollaborationData {
   allocations: Allocation[];
   constraints: ConstraintWrapper[];
   lockedStudents: [string, string][];
 }
+
+/** STOMP auto-reconnect delay (ms). 0 disables reconnect. */
+const RECONNECT_DELAY_MS = 5000;
+
 @Injectable({
   providedIn: 'root',
 })
@@ -17,34 +23,92 @@ export class WebsocketService {
 
   private readonly url = location.hostname;
   private readonly secure = location.protocol === 'https:';
+  /** Reactive connection state — true while the STOMP socket is open. */
+  private readonly connectedSubject$ = new BehaviorSubject<boolean>(false);
 
-  constructor() { }
+  /** Observable connection state for UI bindings (e.g. nav-bar indicator). */
+  get connected$(): Observable<boolean> {
+    return this.connectedSubject$.asObservable();
+  }
+
+  /** Synchronous accessor for the current connection state. */
+  get isConnected(): boolean {
+    return this.connectedSubject$.getValue();
+  }
 
   private async connect(): Promise<boolean> {
-    return new Promise((resolve, reject) => {
+    return new Promise(resolve => {
       if (this.connection?.connected) {
+        this.connectedSubject$.next(true);
         resolve(true);
         return;
       }
-      this.connection = Stomp.client(
+      const client = Stomp.client(
         `${this.secure ? 'wss' : 'ws'}://${this.url}/ws?token=${localStorage.getItem(GLOBALS.LS_KEY_JWT)}`
       );
+      // Auto-reconnect every 5 s if the underlying socket drops. Subscriptions
+      // do not auto-restore — collaboration callers should listen on
+      // `connected$` and re-subscribe on transitions false → true.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (client as any).reconnect_delay = RECONNECT_DELAY_MS;
+      // Quiet the noisy default debug logger.
+      client.debug = () => {
+        /* no-op */
+      };
+      this.connection = client;
+
+      const onClose = () => {
+        this.connectedSubject$.next(false);
+      };
+      // Both legacy and new APIs expose this hook with slightly different
+      // names — set both defensively.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (client as any).onWebSocketClose = onClose;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (client as any).onDisconnect = onClose;
 
       try {
-        this.connection.connect({}, () => {
-          resolve(true);
-        });
-      } catch (error) {
-        reject(false);
+        this.connection.connect(
+          {},
+          () => {
+            this.connectedSubject$.next(true);
+            resolve(true);
+          },
+          () => {
+            // Connection error callback (legacy stomp.js API).
+            this.connectedSubject$.next(false);
+            resolve(false);
+          }
+        );
+      } catch {
+        this.connectedSubject$.next(false);
+        resolve(false);
       }
     });
   }
 
-  async send(courseIterationId: string, path: string, text?: string): Promise<void> {
+  /**
+   * Send a STOMP message to `/app/course-iteration/{id}/{path}`.
+   *
+   * @returns true when the frame was handed to the STOMP client, false when
+   *   the connection is not open. Callers that care about delivery (e.g.
+   *   constraint / allocation broadcasts) should branch on this and surface
+   *   an explicit "not synced" warning instead of treating the call as
+   *   fire-and-forget.
+   */
+  send(courseIterationId: string, path: string, text?: string): boolean {
     if (!this.connection?.connected) {
-      return;
+      this.connectedSubject$.next(false);
+      return false;
     }
-    this.connection.send(`/app/course-iteration/${courseIterationId}/${path}`, {}, text);
+    try {
+      this.connection.send(`/app/course-iteration/${courseIterationId}/${path}`, {}, text);
+      return true;
+    } catch {
+      // Mark disconnected so the auto-reconnect path can take over.
+      this.connectedSubject$.next(false);
+      return false;
+    }
   }
 
   async subscribe(

--- a/client/src/app/shared/services/collaboration.service.ts
+++ b/client/src/app/shared/services/collaboration.service.ts
@@ -8,6 +8,7 @@ import { StompSubscription } from '@stomp/stompjs';
 import { ConfirmationOverlayComponent } from 'src/app/components/confirmation-overlay/confirmation-overlay.component';
 import { GLOBALS } from '../utils/constants';
 import { ToastsService } from './toasts.service';
+import { Subscription, distinctUntilChanged, pairwise, startWith } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -15,6 +16,10 @@ import { ToastsService } from './toasts.service';
 export class CollaborationService implements OnDestroy {
   private discoverySubscription?: StompSubscription;
   private subscriptions: StompSubscription[] = [];
+  /** Tracks the last known connection state so we can warn on transitions. */
+  private connectionWatchSub: Subscription | null = null;
+  /** Course iteration we last subscribed to — needed to re-subscribe on reconnect. */
+  private activeCourseIterationId: string | null = null;
 
   constructor(
     private websocketService: WebsocketService,
@@ -30,6 +35,7 @@ export class CollaborationService implements OnDestroy {
       subscription.unsubscribe();
     }
     this.discoverySubscription?.unsubscribe();
+    this.connectionWatchSub?.unsubscribe();
   }
 
   private async discover(courseIterationId: string): Promise<CollaborationData> {
@@ -58,10 +64,56 @@ export class CollaborationService implements OnDestroy {
   }
 
   private async subscribe(courseIterationId: string): Promise<void> {
+    this.activeCourseIterationId = courseIterationId;
     await this.subscribeToAllocations(courseIterationId);
     await this.subscribeToLockedStudents(courseIterationId);
     await this.subscribeToConstraints(courseIterationId);
+    this.startConnectionWatch();
     this.toatsService.showToast('Connected to Collaboration', 'Success', true);
+  }
+
+  /**
+   * Watch the underlying STOMP connection and react to lifecycle changes.
+   * On a true → false transition we warn the user (silent send drops are
+   * the worst-case for collaboration UX). On false → true (auto-reconnect
+   * succeeded), we re-establish topic subscriptions and re-broadcast our
+   * current state so peers stay in sync.
+   */
+  private startConnectionWatch(): void {
+    if (this.connectionWatchSub) return;
+    this.connectionWatchSub = this.websocketService.connected$
+      .pipe(distinctUntilChanged(), startWith(true), pairwise())
+      .subscribe(([prev, curr]) => {
+        if (prev && !curr) {
+          this.toatsService.showToast(
+            'Lost connection to collaboration. Edits may not sync until reconnected.',
+            'Collaboration offline',
+            false
+          );
+        } else if (!prev && curr && this.activeCourseIterationId) {
+          // Auto-reconnect succeeded — rebind the subscriptions because the
+          // STOMP CompatClient does not preserve them across reconnects.
+          void this.rebindAfterReconnect(this.activeCourseIterationId);
+        }
+      });
+  }
+
+  /** Rebuild topic subscriptions and push our current state after a reconnect. */
+  private async rebindAfterReconnect(courseIterationId: string): Promise<void> {
+    for (const sub of this.subscriptions) sub.unsubscribe();
+    this.subscriptions = [];
+    try {
+      await this.subscribeToAllocations(courseIterationId);
+      await this.subscribeToLockedStudents(courseIterationId);
+      await this.subscribeToConstraints(courseIterationId);
+      this.toatsService.showToast('Reconnected to collaboration.', 'Collaboration', true);
+    } catch {
+      this.toatsService.showToast(
+        'Could not re-subscribe after reconnect. Please reconnect manually.',
+        'Collaboration',
+        false
+      );
+    }
   }
 
   async connect(courseIterationId: string): Promise<void> {
@@ -115,8 +167,11 @@ export class CollaborationService implements OnDestroy {
       subscription.unsubscribe();
     }
     this.subscriptions = [];
+    this.connectionWatchSub?.unsubscribe();
+    this.connectionWatchSub = null;
+    this.activeCourseIterationId = null;
 
-    this.websocketService.connection.disconnect();
+    this.websocketService.connection?.disconnect();
   }
 
   private async subscribeToAllocations(courseIterationId: string): Promise<void> {

--- a/client/src/app/shared/services/collaboration.service.ts
+++ b/client/src/app/shared/services/collaboration.service.ts
@@ -8,7 +8,7 @@ import { StompSubscription } from '@stomp/stompjs';
 import { ConfirmationOverlayComponent } from 'src/app/components/confirmation-overlay/confirmation-overlay.component';
 import { GLOBALS } from '../utils/constants';
 import { ToastsService } from './toasts.service';
-import { Subscription, distinctUntilChanged, pairwise, startWith } from 'rxjs';
+import { Subscription, distinctUntilChanged } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -20,6 +20,8 @@ export class CollaborationService implements OnDestroy {
   private connectionWatchSub: Subscription | null = null;
   /** Course iteration we last subscribed to — needed to re-subscribe on reconnect. */
   private activeCourseIterationId: string | null = null;
+  /** Previous value seen by the connection watcher; undefined until the first emission. */
+  private lastSeenConnected: boolean | undefined = undefined;
 
   constructor(
     private websocketService: WebsocketService,
@@ -81,9 +83,17 @@ export class CollaborationService implements OnDestroy {
    */
   private startConnectionWatch(): void {
     if (this.connectionWatchSub) return;
+    // Anchor on the actual current value of the BehaviorSubject so the
+    // initial seed replay does not look like a transition. Avoids
+    // `startWith(true)`'s implicit assumption that we were previously
+    // connected (which gave a spurious "offline" toast on cold start).
+    this.lastSeenConnected = this.websocketService.isConnected;
     this.connectionWatchSub = this.websocketService.connected$
-      .pipe(distinctUntilChanged(), startWith(true), pairwise())
-      .subscribe(([prev, curr]) => {
+      .pipe(distinctUntilChanged())
+      .subscribe(curr => {
+        const prev = this.lastSeenConnected;
+        this.lastSeenConnected = curr;
+        if (prev === undefined || prev === curr) return;
         if (prev && !curr) {
           this.toatsService.showToast(
             'Lost connection to collaboration. Edits may not sync until reconnected.',
@@ -91,22 +101,29 @@ export class CollaborationService implements OnDestroy {
             false
           );
         } else if (!prev && curr && this.activeCourseIterationId) {
-          // Auto-reconnect succeeded — rebind the subscriptions because the
-          // STOMP CompatClient does not preserve them across reconnects.
+          // Auto-reconnect succeeded — rebind via the full connect() flow
+          // (discover + diff overlay) so a peer's newer state can never
+          // be silently overwritten by our offline-collected local edits.
           void this.rebindAfterReconnect(this.activeCourseIterationId);
         }
       });
   }
 
-  /** Rebuild topic subscriptions and push our current state after a reconnect. */
+  /**
+   * Reconnect rebind. Routes through the same `connect()` flow used on
+   * cold start so the discovery handshake + diff overlay run again —
+   * without that, any local edits made while offline would silently
+   * clobber a peer's newer state because the topic broadcasts that
+   * `subscribeToX` does on (re-)subscribe push the FULL local snapshot
+   * to the server.
+   */
   private async rebindAfterReconnect(courseIterationId: string): Promise<void> {
     for (const sub of this.subscriptions) sub.unsubscribe();
     this.subscriptions = [];
+    this.discoverySubscription?.unsubscribe();
+    this.discoverySubscription = undefined;
     try {
-      await this.subscribeToAllocations(courseIterationId);
-      await this.subscribeToLockedStudents(courseIterationId);
-      await this.subscribeToConstraints(courseIterationId);
-      this.toatsService.showToast('Reconnected to collaboration.', 'Collaboration', true);
+      await this.connect(courseIterationId);
     } catch {
       this.toatsService.showToast(
         'Could not re-subscribe after reconnect. Please reconnect manually.',
@@ -169,6 +186,7 @@ export class CollaborationService implements OnDestroy {
     this.subscriptions = [];
     this.connectionWatchSub?.unsubscribe();
     this.connectionWatchSub = null;
+    this.lastSeenConnected = undefined;
     this.activeCourseIterationId = null;
 
     this.websocketService.connection?.disconnect();


### PR DESCRIPTION
`fix/collaboration-distribute-sync` is rebased onto `feat/automated-prompt-tease-data-exchange` (clean replay; one resolved conflict — combined the upstream `NgZone.run` wrapper with the collab branch's
  re-broadcast in `distributeTeams`). Two commits on the branch:
                                                                                                                                                                                                                    - `f8da024a` — original collab fix (re-broadcast in distribute, multi-origin send-returns-bool, reconnect handling)
  - `7cc661f1` — audit fixes from this iteration

  ## What the audit found

  Verdict was **ship-with-fixes**. Four issues, two materially affecting "latter changes win":

  | # | Finding | Status |
  |---|---|---|
  | 1 | `rebindAfterReconnect` sent local state before subscribing → could silently clobber a peer's newer edits made while we were offline | **Fixed** — rebind now goes through the full `connect()` flow with discovery + diff overlay |
  | 2 | `startConnectionWatch`'s `startWith(true)` would fire a spurious "Lost connection" toast on cold start and mis-classify the first connect as a reconnect | **Fixed** — manual prev-value tracker anchored on `websocketService.isConnected` |
  | 3 | Failed `send()` during distribute is silently dropped if the WS is down — no retry queue | Not addressed (out of scope; would need a queueing layer) |
  | 4 | Three separate topic broadcasts in `distributeTeams` have no atomic ordering guarantee on the wire | Not addressed (would need a server-side bundled topic) |

  ## "Latter changes win" property — verified

  - **Concurrent distributes:** the server's per-topic `HashMap` slot keeps the LAST frame received. Both clients converge on that. Holds.
  - **Drag-drop while peer distributes:** same — last writer wins per topic. Holds.
  - **WS hiccup mid-edit:** failed sends are now visible (toast + red pill), reconnect runs discovery, diff overlay surfaces if state diverged. Holds — no longer silent overwrite.
  - **Edge:** if you edit offline and a peer also edits, the diff overlay asks you to choose. The "latter changes win" property bends to "user gets to decide", which is the safer default than auto-clobbering.
