### PR TITLE
 PR depends on previous PR;Add greedy matching strategy explanation to constraint summary UI

### DIFF
--- a/client/src/app/components/constraint-summary-view/constraint-summary.component.html
+++ b/client/src/app/components/constraint-summary-view/constraint-summary.component.html
@@ -13,6 +13,18 @@
           Add Constraint
         </button>
       </div>
+      
+     @if (isCompanyGreedyMode) {
+        <div class="greedy-strategy-note">
+          <div class="fw-semibold mb-1">Greedy Matching Strategy</div>
+          <div class="mb-0">
+            The system builds matches step by step by selecting the best currently available option. Participants are
+            organized into priority tiers, and higher-priority candidates are matched first. This makes the process fast
+            and efficient for larger datasets, but because each decision is made locally, the final allocation may not
+            always be the globally optimal solution.
+          </div>
+        </div>
+      }
 
       @if (constraintWrappers.length) {
         <div class="border border-1 rounded-3 table-container overflow-y-scroll">

--- a/client/src/app/components/constraint-summary-view/constraint-summary.component.scss
+++ b/client/src/app/components/constraint-summary-view/constraint-summary.component.scss
@@ -39,3 +39,12 @@ th {
     }
   }
 }
+
+.greedy-strategy-note {
+  padding: 0.875rem 1rem;
+  border: 1px solid $border-color;
+  border-radius: 0.5rem;
+  background: $accent-color-light;
+  color: $text-color;
+  line-height: 1.5;
+}

--- a/client/src/app/components/constraint-summary-view/constraint-summary.component.ts
+++ b/client/src/app/components/constraint-summary-view/constraint-summary.component.ts
@@ -24,8 +24,7 @@ import { ToastsService } from 'src/app/shared/services/toasts.service';
 import { StudentSortService } from 'src/app/shared/services/student-sort.service';
 import { ConstraintBuilderNationalityComponent } from '../constraint-builder-nationality/constraint-builder-nationality.component';
 import { Subscription } from 'rxjs';
-import { MatchingRouterService } from 'src/app/shared/matching/matching-router.service';
-import { CourseIterationsService } from 'src/app/shared/data/course-iteration.service';
+import { MatchingMode, MatchingRouterService } from 'src/app/shared/matching/matching-router.service';import { CourseIterationsService } from 'src/app/shared/data/course-iteration.service';
 
 @Component({
   selector: 'app-constraint-summary',
@@ -48,6 +47,7 @@ export class ConstraintSummaryComponent implements OverlayComponentData, OnInit,
 
   constraintWrappers: ConstraintWrapper[] = [];
   projects: Project[] = [];
+  matchingMode: MatchingMode;
 
   private subscription: Subscription;
 
@@ -69,6 +69,13 @@ export class ConstraintSummaryComponent implements OverlayComponentData, OnInit,
       this.constraintWrappers = constraintWrappers;
     });
     this.projects = this.projectsService.getProjects();
+    this.matchingMode = this.matchingRouterService.getMatchingMode({
+      students: this.studentsService.getStudents(),
+      projects: this.projects,
+      constraintWrappers: this.constraintWrappers,
+      locks: this.lockedStudentsService.getLocks(),
+      courseIteration: this.courseIterationsService.getCourseIteration(),
+    });
   }
 
   ngOnDestroy(): void {
@@ -119,5 +126,9 @@ export class ConstraintSummaryComponent implements OverlayComponentData, OnInit,
   setActive(id: string, active: boolean): void {
     this.constraintsService.setActive(id, active);
     this.constraintWrappers = this.constraintsService.getConstraints();
+  }
+
+  get isCompanyGreedyMode(): boolean {
+    return this.matchingMode === 'company-greedy';
   }
 }


### PR DESCRIPTION
## Summary

Adds an explanation panel to the constraint summary overlay for the company-greedy matching workflow.

When the current course uses greedy matching, the UI now shows a short description explaining that the system matches step by step using priority tiers, is fast for larger datasets, and may not produce the globally optimal overall solution. LP behavior and UI remain unchanged.

## Changes

Add matchingMode state to ConstraintSummaryComponent.
Determine matching mode on init via MatchingRouterService.
Add isCompanyGreedyMode helper for template rendering.
Render a greedy-only informational note in the constraint summary overlay.
Add styling for the strategy note to present it as contextual guidance.

## Why
The greedy workflow behaves differently from the LP-based matching flow, so users should understand the tradeoff before. clicking Distribute Teams. This adds that context at the point of action without changing the LP experience.