### PR TITLE
Dependencies: tune Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,21 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
+  "extends": ["config:recommended"],
+  "semanticCommits": "disabled",
+  "commitMessagePrefix": "Dependencies:",
+  "prConcurrentLimit": 3,
+  "rangeStrategy": "bump",
+  "minimumReleaseAge": "7 days",
+  "packageRules": [
+    {
+      "description": "Group all non-major updates together",
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "all non-major dependencies"
+    },
+    {
+      "description": "No minimum age for security updates",
+      "matchCategories": ["security"],
+      "minimumReleaseAge": "0 days"
+    }
   ]
 }


### PR DESCRIPTION
Updates `renovate.json`:

- Disable semantic commits; prefix commits with `Dependencies:`
- Cap concurrent PRs at 3
- `rangeStrategy: bump`
- Require a 7-day minimum release age (0 days for security updates)
- Group all non-major (minor + patch) updates into a single PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to better organize incoming changes.
  * Combined non-major dependency updates into a single weekly-style pull request.
  * Allowed security updates to bypass the normal waiting period.
  * Reduced the number of simultaneous update pull requests and adjusted dependency commit messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->